### PR TITLE
Fix form data not being sent to Google Sheets via Zapier

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,19 +648,6 @@
             <div class="signup-form">
                 <h3>Join the Fan Club</h3>
                 <form id="fanclubForm">
-                    <!-- Web3Forms Access Key -->
-                    <input type="hidden" name="access_key" value="849b83c2-85b1-495c-8074-a020510f09b7">
-                    
-                    <!-- Zapier Webhook URL -->
-                    <input type="hidden" name="redirect" value="https://hooks.zapier.com/hooks/catch/25289939/usc27w8/">
-
-                    <!-- Zapier Webhook URL -->
-                    <input type="hidden" name="redirect" value="https://hooks.zapier.com/hooks/catch/25289939/usc27w8/">
-
-                    <!-- Email Configuration -->
-                    <input type="hidden" name="subject" value="New Fan Club Member Request">
-                    <input type="hidden" name="from_name" value="Harrison Dessoy Fan Club">
-
                     <div class="form-group">
                         <label for="name">Full Name</label>
                         <input type="text" id="name" name="name" required>
@@ -732,6 +719,14 @@
             const submitButton = form.querySelector('.submit-button');
             const formData = new FormData(form);
 
+            // Convert FormData to JSON object
+            const data = {
+                name: formData.get('name'),
+                email: formData.get('email'),
+                country: formData.get('country'),
+                message: formData.get('message') || ''
+            };
+
             // Remove any existing messages
             const existingMessage = form.querySelector('.form-message');
             if (existingMessage) {
@@ -743,14 +738,16 @@
             submitButton.textContent = 'Submitting...';
 
             try {
-                const response = await fetch('https://api.web3forms.com/submit', {
+                // Send directly to Zapier webhook
+                const response = await fetch('https://hooks.zapier.com/hooks/catch/25289939/usc27w8/', {
                     method: 'POST',
-                    body: formData
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify(data)
                 });
 
-                const data = await response.json();
-
-                if (data.success) {
+                if (response.ok) {
                     // Show success message
                     const successMessage = document.createElement('div');
                     successMessage.className = 'form-message success';
@@ -763,7 +760,7 @@
                     // Scroll to message
                     successMessage.scrollIntoView({ behavior: 'smooth', block: 'center' });
                 } else {
-                    throw new Error(data.message || 'Something went wrong');
+                    throw new Error('Failed to submit form');
                 }
             } catch (error) {
                 // Show error message


### PR DESCRIPTION
The form was previously sending data to Web3Forms which attempted to use a redirect parameter to forward to Zapier. However, the redirect parameter only redirects the user's browser, not the form data.

Changes:
- Remove Web3Forms integration entirely
- Send form data directly to Zapier webhook as JSON
- Properly structure data with name, email, country, and message fields

This ensures Zapier receives the actual form values and can populate the Google Sheet correctly.