### PR TITLE
Fix CORS error by removing Content-Type header from Zapier webhook re…

### DIFF
--- a/index.html
+++ b/index.html
@@ -719,14 +719,6 @@
             const submitButton = form.querySelector('.submit-button');
             const formData = new FormData(form);
 
-            // Convert FormData to JSON object
-            const data = {
-                name: formData.get('name'),
-                email: formData.get('email'),
-                country: formData.get('country'),
-                message: formData.get('message') || ''
-            };
-
             // Remove any existing messages
             const existingMessage = form.querySelector('.form-message');
             if (existingMessage) {
@@ -738,14 +730,11 @@
             submitButton.textContent = 'Submitting...';
 
             try {
-                // Send directly to Zapier webhook
-                console.log('Submitting form data:', data);
+                // Send as form-encoded data to avoid CORS preflight
+                console.log('Submitting form data to Zapier');
                 const response = await fetch('https://hooks.zapier.com/hooks/catch/25289939/usc27w8/', {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify(data)
+                    body: formData
                 });
 
                 console.log('Response status:', response.status);


### PR DESCRIPTION
…quest

The form was sending JSON with a Content-Type header, which triggered a CORS preflight request that failed. Zapier webhooks don't allow custom headers in the Access-Control-Allow-Headers.

Solution: Send FormData directly without specifying Content-Type header. This sends the data as application/x-www-form-urlencoded by default, which doesn't require a preflight request.