### PR TITLE
Fix form data not appearing in Google Sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,11 +730,19 @@
             submitButton.textContent = 'Submitting...';
 
             try {
-                // Send as form-encoded data to avoid CORS preflight
+                // Convert FormData to URL-encoded format for proper Zapier parsing
+                const urlEncodedData = new URLSearchParams();
+                for (const [key, value] of formData.entries()) {
+                    urlEncodedData.append(key, value);
+                }
+
                 console.log('Submitting form data to Zapier');
                 const response = await fetch('https://hooks.zapier.com/hooks/catch/25289939/usc27w8/', {
                     method: 'POST',
-                    body: formData
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: urlEncodedData.toString()
                 });
 
                 console.log('Response status:', response.status);


### PR DESCRIPTION
Convert form submission from multipart/form-data to application/x-www-form-urlencoded format so Zapier can properly parse individual form fields (name, email, country, message) and send them to Google Sheets.