### PR TITLE
Change form submission to JSON format for better Zapier parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,19 +730,19 @@
             submitButton.textContent = 'Submitting...';
 
             try {
-                // Convert FormData to URL-encoded format for proper Zapier parsing
-                const urlEncodedData = new URLSearchParams();
+                // Convert FormData to JSON object for Zapier parsing
+                const jsonData = {};
                 for (const [key, value] of formData.entries()) {
-                    urlEncodedData.append(key, value);
+                    jsonData[key] = value;
                 }
 
-                console.log('Submitting form data to Zapier');
+                console.log('Submitting form data to Zapier:', jsonData);
                 const response = await fetch('https://hooks.zapier.com/hooks/catch/25289939/usc27w8/', {
                     method: 'POST',
                     headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded'
+                        'Content-Type': 'application/json'
                     },
-                    body: urlEncodedData.toString()
+                    body: JSON.stringify(jsonData)
                 });
 
                 console.log('Response status:', response.status);


### PR DESCRIPTION
Convert form data to JSON instead of URL-encoded format. Zapier automatically parses JSON into individual fields (name, email, country, message) that can be easily mapped to Google Sheets columns.