### PR TITLE
Revert about page image positioning and adjust home page hero image

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
             background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
                         url('images/2025_profilepic.png');
             background-size: cover;
-            background-position: center;
+            background-position: center 30%;
             height: 100vh;
             display: flex;
             align-items: center;
@@ -695,7 +695,7 @@
             <h2>About Harrison</h2>
             <div class="about-grid">
                 <div class="about-image" style="background: none; overflow: hidden;">
-                    <img src="images/2025_profilepic.png" alt="Harrison Dessoy" style="width: 100%; height: 100%; object-fit: cover; object-position: center 20%; border-radius: 10px; display: block;" onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);color:white;font-size:3rem;font-weight:bold;\'>Image Not Found - Check Path</div>'">
+                    <img src="images/2025_profilepic.png" alt="Harrison Dessoy" style="width: 100%; height: 100%; object-fit: cover; border-radius: 10px; display: block;" onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);color:white;font-size:3rem;font-weight:bold;\'>Image Not Found - Check Path</div>'">
                 </div>
                 <div class="about-content">
                     <p>Harrison Dessoy is an elite athlete preparing to compete at the highest level of motorcycle racing in 2026. With years of dedication, training, and passion for motorsport, Harrison represents the next generation of world-class racing talent.</p>


### PR DESCRIPTION
- Removed object-position from about section profile image (reverts previous change)
- Adjusted home page hero background-position to center 30% to move image down