### PR TITLE
Update PHR Performance page with corrected descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,8 +782,8 @@
             <div class="sponsors-grid">
                 <div class="sponsor-card">
                     <div class="sponsor-logo">PHR Performance</div>
-                    <h3>Technical Partner</h3>
-                    <p>PHR Performance by Peter Hickman provides world-class technical expertise and championship-winning insights, supporting Harrison with setup optimization and race craft development.</p>
+                    <h3>Harrison Race Team</h3>
+                    <p>PHR Performance by Peter Hickman provides world-class technical expertise and championship-winning insights, supporting Harrison with setup optimisation and race craft development.</p>
                     <a href="sponsor-phr-performance.html" style="display: inline-block; margin-top: 1rem; padding: 0.5rem 1.5rem; background: var(--primary); color: var(--light); text-decoration: none; border-radius: 5px; font-weight: bold;">Learn More →</a>
                 </div>
 

--- a/sponsor-phr-performance.html
+++ b/sponsor-phr-performance.html
@@ -270,17 +270,17 @@
 
     <div class="sponsor-hero">
         <h1>PHR Performance by Peter Hickman</h1>
-        <p>Official Technical Partner of Harrison Dessoy</p>
+        <p>Harrison Dessoy Race Team</p>
     </div>
 
     <main>
         <section class="content-section">
             <h2>About PHR Performance</h2>
-            <p>PHR Performance, founded and led by British Superbike Champion and Isle of Man TT legend Peter Hickman, represents the pinnacle of motorcycle racing expertise and technical excellence. With Peter's unparalleled experience at the highest levels of motorcycle racing, PHR Performance brings world-class knowledge and championship-winning insights to every partnership.</p>
+            <p>PHR Performance, founded and led by multiple British Superbike winner and Isle of Man TT legend Peter Hickman, represents the pinnacle of motorcycle racing expertise and technical excellence. With Peter's unparalleled experience at the highest levels of motorcycle racing, PHR Performance brings world-class knowledge and championship-winning insights to every partnership.</p>
 
             <p>Peter Hickman's achievements speak for themselves - a multiple-time winner at the Isle of Man TT, lap record holder, and British Superbike Championship race winner. This wealth of racing experience at the absolute highest level is what makes PHR Performance uniquely qualified to support Harrison's journey to elite-level racing.</p>
 
-            <p>PHR Performance specializes in providing comprehensive technical support, setup expertise, and performance optimization for riders competing at the highest levels of motorcycle racing. Their hands-on approach combines Peter's racing insights with cutting-edge technical knowledge to help riders extract maximum performance from their machines.</p>
+            <p>PHR Performance specialises in providing comprehensive technical support, setup expertise, and performance optimisation for riders competing at the highest levels of motorcycle racing. Their hands-on approach combines Peter's racing insights with cutting-edge technical knowledge to help riders extract maximum performance from their machines.</p>
         </section>
 
         <section class="content-section">
@@ -331,7 +331,7 @@
 
         <section class="content-section">
             <h2>Why PHR Performance?</h2>
-            <p>Choosing PHR Performance as a technical partner means gaining access to genuine world-class racing expertise. Peter Hickman's credentials include:</p>
+            <p>Choosing PHR Performance as Harrison's race team means gaining access to genuine world-class racing expertise. Peter Hickman's credentials include:</p>
 
             <div class="stats-section">
                 <div class="stat-box">
@@ -345,10 +345,6 @@
                 <div class="stat-box">
                     <h3>BSB</h3>
                     <p>Race Winner</p>
-                </div>
-                <div class="stat-box">
-                    <h3>Elite</h3>
-                    <p>Expertise</p>
                 </div>
             </div>
 


### PR DESCRIPTION
- Changed Peter Hickman description from "British Superbike Champion" to "multiple British Superbike winner"
- Updated US English to UK English spellings (specialize → specialise, optimization → optimisation)
- Changed PHR role from "Technical Partner" to "Harrison Race Team" across both pages
- Removed the "Elite" statistics box from PHR sponsor page