### PR TITLE
Add Eastern Garage Racing to sponsors section on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,6 +816,13 @@
                 </div>
 
                 <div class="sponsor-card">
+                    <div class="sponsor-logo">Eastern Garage Racing</div>
+                    <h3>Product Partner</h3>
+                    <p>Martin Sheath and Eastern Garage Racing provide automotive expertise and support, bringing over 70 years of professional service excellence to Harrison's racing career.</p>
+                    <a href="sponsor-martin-sheath.html" style="display: inline-block; margin-top: 1rem; padding: 0.5rem 1.5rem; background: var(--primary); color: var(--light); text-decoration: none; border-radius: 5px; font-weight: bold;">Learn More →</a>
+                </div>
+
+                <div class="sponsor-card">
                     <div class="sponsor-logo">Triumph East London</div>
                     <h3>Dealership Partner</h3>
                     <p>Triumph East London offers expert Triumph motorcycle services and support, representing iconic British motorcycling heritage and professional excellence.</p>


### PR DESCRIPTION
Added Martin Sheath / Eastern Garage Racing as a Product Partner in the sponsors section of the main page, linking to the newly created sponsor detail page.