### PR TITLE
Remove 2026 events tile from news section

### DIFF
--- a/index.html
+++ b/index.html
@@ -829,16 +829,6 @@
                         <a href="behind-the-scenes.html" class="read-more">Read More →</a>
                     </div>
                 </div>
-
-                <div class="blog-card">
-                    <div class="blog-image">2026 Events</div>
-                    <div class="blog-content">
-                        <p class="blog-date">2026 Season</p>
-                        <h3>Racing Calendar</h3>
-                        <p>View the complete 2026 World Superbike Championship calendar and find out where Harrison will be racing.</p>
-                        <a href="events.html" class="read-more">View Events →</a>
-                    </div>
-                </div>
             </div>
         </section>
 


### PR DESCRIPTION
The 2026 events tile has been removed from the Latest News section as the Harrison world superbike ride announcement is scheduled for next week. The events.html page remains intact.