### PR TITLE
Update Events page with correct 2026 racing calendar

### DIFF
--- a/events.html
+++ b/events.html
@@ -306,190 +306,131 @@
 
     <main>
         <div class="page-hero">
+            <img src="images/SBK_Logo.jpg" alt="World Sportbike Logo" style="max-width: 200px; margin-bottom: 1.5rem; border-radius: 10px;">
             <h1>2026 Racing Calendar</h1>
             <p>Follow Harrison Dessoy through the world's premier motorcycle racing championship</p>
         </div>
 
-        <h2>Worldsuperbike races</h2>
+        <h2>World Sportbike Races</h2>
 
         <div class="races-grid">
-            <!-- Round 1 -->
+            <!-- Round 2 - Portuguese Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/phillip-island.jpg" alt="Phillip Island Circuit" onerror="this.parentElement.innerHTML='Phillip Island'">
+                    <img src="images/tracks/portimao.jpg" alt="Portuguese Round" onerror="this.parentElement.innerHTML='Portugal'">
                 </div>
-                <div class="race-date">February 21-23</div>
-                <div class="race-country">
-                    <span class="country-flag">🇦🇺</span>
-                    <span>Australia</span>
-                </div>
-                <div class="track-name">Phillip Island Circuit</div>
-                <div class="track-length">4.448 km</div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
-
-            <!-- Round 2 -->
-            <div class="race-row">
-                <div class="track-image">
-                    <img src="images/tracks/mandalika.jpg" alt="Mandalika International Street Circuit" onerror="this.parentElement.innerHTML='Mandalika'">
-                </div>
-                <div class="race-date">March 14-16</div>
-                <div class="race-country">
-                    <span class="country-flag">🇮🇩</span>
-                    <span>Indonesia</span>
-                </div>
-                <div class="track-name">Mandalika International Street Circuit</div>
-                <div class="track-length">4.310 km</div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
-
-            <!-- Round 3 -->
-            <div class="race-row">
-                <div class="track-image">
-                    <img src="images/tracks/aragon.jpg" alt="MotorLand Aragón" onerror="this.parentElement.innerHTML='Aragón'">
-                </div>
-                <div class="race-date">April 4-6</div>
-                <div class="race-country">
-                    <span class="country-flag">🇪🇸</span>
-                    <span>Spain</span>
-                </div>
-                <div class="track-name">MotorLand Aragón</div>
-                <div class="track-length">5.077 km</div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
-
-            <!-- Round 4 -->
-            <div class="race-row">
-                <div class="track-image">
-                    <img src="images/tracks/assen.jpg" alt="TT Circuit Assen" onerror="this.parentElement.innerHTML='Assen'">
-                </div>
-                <div class="race-date">April 25-27</div>
-                <div class="race-country">
-                    <span class="country-flag">🇳🇱</span>
-                    <span>Netherlands</span>
-                </div>
-                <div class="track-name">TT Circuit Assen</div>
-                <div class="track-length">4.542 km</div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
-
-            <!-- Round 5 -->
-            <div class="race-row">
-                <div class="track-image">
-                    <img src="images/tracks/imola.jpg" alt="Autodromo Enzo e Dino Ferrari" onerror="this.parentElement.innerHTML='Imola'">
-                </div>
-                <div class="race-date">May 9-11</div>
-                <div class="race-country">
-                    <span class="country-flag">🇮🇹</span>
-                    <span>Italy</span>
-                </div>
-                <div class="track-name">Autodromo Enzo e Dino Ferrari</div>
-                <div class="track-length">4.936 km</div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
-
-            <!-- Round 6 -->
-            <div class="race-row">
-                <div class="track-image">
-                    <img src="images/tracks/donington.jpg" alt="Donington Park" onerror="this.parentElement.innerHTML='Donington'">
-                </div>
-                <div class="race-date">May 23-25</div>
-                <div class="race-country">
-                    <span class="country-flag">🇬🇧</span>
-                    <span>United Kingdom</span>
-                </div>
-                <div class="track-name">Donington Park</div>
-                <div class="track-length">4.023 km</div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
-
-            <!-- Round 7 -->
-            <div class="race-row">
-                <div class="track-image">
-                    <img src="images/tracks/misano.jpg" alt="Misano World Circuit Marco Simoncelli" onerror="this.parentElement.innerHTML='Misano'">
-                </div>
-                <div class="race-date">June 13-15</div>
-                <div class="race-country">
-                    <span class="country-flag">🇮🇹</span>
-                    <span>Italy</span>
-                </div>
-                <div class="track-name">Misano World Circuit Marco Simoncelli</div>
-                <div class="track-length">4.226 km</div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
-
-            <!-- Round 8 -->
-            <div class="race-row">
-                <div class="track-image">
-                    <img src="images/tracks/most.jpg" alt="Autodrom Most" onerror="this.parentElement.innerHTML='Most'">
-                </div>
-                <div class="race-date">July 18-20</div>
-                <div class="race-country">
-                    <span class="country-flag">🇨🇿</span>
-                    <span>Czech Republic</span>
-                </div>
-                <div class="track-name">Autodrom Most</div>
-                <div class="track-length">4.212 km</div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
-
-            <!-- Round 9 -->
-            <div class="race-row">
-                <div class="track-image">
-                    <img src="images/tracks/portimao.jpg" alt="Autódromo Internacional do Algarve" onerror="this.parentElement.innerHTML='Portimão'">
-                </div>
-                <div class="race-date">August 8-10</div>
+                <div class="race-date">March 20-22</div>
                 <div class="race-country">
                     <span class="country-flag">🇵🇹</span>
-                    <span>Portugal</span>
+                    <span>Portuguese Round</span>
                 </div>
-                <div class="track-name">Autódromo Internacional do Algarve</div>
-                <div class="track-length">4.592 km</div>
+                <div class="track-name">Round 2</div>
+                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
-            <!-- Round 10 -->
+            <!-- Round 3 - Dutch Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/magny-cours.jpg" alt="Circuit de Nevers Magny-Cours" onerror="this.parentElement.innerHTML='Magny-Cours'">
+                    <img src="images/tracks/assen.jpg" alt="Dutch Round" onerror="this.parentElement.innerHTML='Netherlands'">
                 </div>
-                <div class="race-date">September 5-7</div>
+                <div class="race-date">April 17-19</div>
+                <div class="race-country">
+                    <span class="country-flag">🇳🇱</span>
+                    <span>Dutch Round</span>
+                </div>
+                <div class="track-name">Round 3</div>
+                <div class="track-length"></div>
+                <button class="race-report-btn">Race Report</button>
+            </div>
+
+            <!-- Round 5 - Czech Round -->
+            <div class="race-row">
+                <div class="track-image">
+                    <img src="images/tracks/most.jpg" alt="Czech Round" onerror="this.parentElement.innerHTML='Czech Republic'">
+                </div>
+                <div class="race-date">May 15-17</div>
+                <div class="race-country">
+                    <span class="country-flag">🇨🇿</span>
+                    <span>Czech Round</span>
+                </div>
+                <div class="track-name">Round 5</div>
+                <div class="track-length"></div>
+                <button class="race-report-btn">Race Report</button>
+            </div>
+
+            <!-- Round 6 - Aragon Round -->
+            <div class="race-row">
+                <div class="track-image">
+                    <img src="images/tracks/aragon.jpg" alt="Aragon Round" onerror="this.parentElement.innerHTML='Aragon'">
+                </div>
+                <div class="race-date">May 29-31</div>
+                <div class="race-country">
+                    <span class="country-flag">🇪🇸</span>
+                    <span>Aragon Round</span>
+                </div>
+                <div class="track-name">Round 6</div>
+                <div class="track-length"></div>
+                <button class="race-report-btn">Race Report</button>
+            </div>
+
+            <!-- Round 7 - Emilia-Romagna Round -->
+            <div class="race-row">
+                <div class="track-image">
+                    <img src="images/tracks/misano.jpg" alt="Emilia-Romagna Round" onerror="this.parentElement.innerHTML='Emilia-Romagna'">
+                </div>
+                <div class="race-date">June 12-14</div>
+                <div class="race-country">
+                    <span class="country-flag">🇮🇹</span>
+                    <span>Emilia-Romagna Round</span>
+                </div>
+                <div class="track-name">Round 7</div>
+                <div class="track-length"></div>
+                <button class="race-report-btn">Race Report</button>
+            </div>
+
+            <!-- Round 9 - French Round -->
+            <div class="race-row">
+                <div class="track-image">
+                    <img src="images/tracks/magny-cours.jpg" alt="French Round" onerror="this.parentElement.innerHTML='France'">
+                </div>
+                <div class="race-date">September 4-6</div>
                 <div class="race-country">
                     <span class="country-flag">🇫🇷</span>
-                    <span>France</span>
+                    <span>French Round</span>
                 </div>
-                <div class="track-name">Circuit de Nevers Magny-Cours</div>
-                <div class="track-length">4.411 km</div>
+                <div class="track-name">Round 9</div>
+                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
-            <!-- Round 11 -->
+            <!-- Round 10 - Italian Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/barcelona.jpg" alt="Circuit de Barcelona-Catalunya" onerror="this.parentElement.innerHTML='Barcelona'">
+                    <img src="images/tracks/imola.jpg" alt="Italian Round" onerror="this.parentElement.innerHTML='Italy'">
                 </div>
-                <div class="race-date">September 19-21</div>
+                <div class="race-date">September 25-27</div>
                 <div class="race-country">
-                    <span class="country-flag">🇪🇸</span>
-                    <span>Spain</span>
+                    <span class="country-flag">🇮🇹</span>
+                    <span>Italian Round</span>
                 </div>
-                <div class="track-name">Circuit de Barcelona-Catalunya</div>
-                <div class="track-length">4.675 km</div>
+                <div class="track-name">Round 10</div>
+                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
-            <!-- Round 12 -->
+            <!-- Round 12 - Spanish Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/jerez.jpg" alt="Circuito de Jerez" onerror="this.parentElement.innerHTML='Jerez'">
+                    <img src="images/tracks/jerez.jpg" alt="Spanish Round" onerror="this.parentElement.innerHTML='Spain'">
                 </div>
-                <div class="race-date">October 17-19</div>
+                <div class="race-date">October 16-18</div>
                 <div class="race-country">
                     <span class="country-flag">🇪🇸</span>
-                    <span>Spain</span>
+                    <span>Spanish Round</span>
                 </div>
-                <div class="track-name">Circuito de Jerez</div>
-                <div class="track-length">4.423 km</div>
+                <div class="track-name">Round 12</div>
+                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
         </div>


### PR DESCRIPTION
- Add SBK logo to the 2026 Racing Calendar hero tile
- Change title from 'Worldsuperbike races' to 'World Sportbike Races'
- Update event tiles with correct rounds and dates:
  - Round 2: Portuguese Round (March 20-22)
  - Round 3: Dutch Round (April 17-19)
  - Round 5: Czech Round (May 15-17)
  - Round 6: Aragon Round (May 29-31)
  - Round 7: Emilia-Romagna Round (June 12-14)
  - Round 9: French Round (September 4-6)
  - Round 10: Italian Round (September 25-27)
  - Round 12: Spanish Round (October 16-18)
- Add country flags to each event tile