### PR TITLE
Update Events page: full logo tile, Portugal link, country codes

### DIFF
--- a/events.html
+++ b/events.html
@@ -305,39 +305,38 @@
     </header>
 
     <main>
-        <div class="page-hero">
-            <img src="images/SBK_Logo.jpg" alt="World Sportbike Logo" style="max-width: 200px; margin-bottom: 1.5rem; border-radius: 10px;">
-            <h1>2026 Racing Calendar</h1>
-            <p>Follow Harrison Dessoy through the world's premier motorcycle racing championship</p>
+        <div class="page-hero" style="background: url('images/SBK_Logo.jpg') center/cover no-repeat; min-height: 300px; display: flex; flex-direction: column; justify-content: center; align-items: center;">
+            <h1 style="text-shadow: 2px 2px 4px rgba(0,0,0,0.8);">2026 Racing Calendar</h1>
+            <p style="text-shadow: 1px 1px 3px rgba(0,0,0,0.8);">Follow Harrison Dessoy through the world's premier motorcycle racing championship</p>
         </div>
 
         <h2>World Sportbike Races</h2>
 
         <div class="races-grid">
             <!-- Round 2 - Portuguese Round -->
-            <div class="race-row">
+            <a href="https://www.worldsbk.com/en/event/POR/2026?utm_campaign=EN_worldSBK&utm_source=web_DessoyRacing" target="_blank" class="race-row" style="text-decoration: none; color: inherit;">
                 <div class="track-image">
-                    <img src="images/tracks/portimao.jpg" alt="Portuguese Round" onerror="this.parentElement.innerHTML='Portugal'">
+                    <img src="images/tracks/portimao.jpg" alt="Portuguese Round" onerror="this.parentElement.innerHTML='PT'">
                 </div>
                 <div class="race-date">March 20-22</div>
                 <div class="race-country">
                     <span class="country-flag">🇵🇹</span>
-                    <span>Portuguese Round</span>
+                    <span>PT</span>
                 </div>
                 <div class="track-name">Round 2</div>
                 <div class="track-length"></div>
-                <button class="race-report-btn">Race Report</button>
-            </div>
+                <span class="race-report-btn">Race Report</span>
+            </a>
 
             <!-- Round 3 - Dutch Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/assen.jpg" alt="Dutch Round" onerror="this.parentElement.innerHTML='Netherlands'">
+                    <img src="images/tracks/assen.jpg" alt="Dutch Round" onerror="this.parentElement.innerHTML='NL'">
                 </div>
                 <div class="race-date">April 17-19</div>
                 <div class="race-country">
                     <span class="country-flag">🇳🇱</span>
-                    <span>Dutch Round</span>
+                    <span>NL</span>
                 </div>
                 <div class="track-name">Round 3</div>
                 <div class="track-length"></div>
@@ -347,12 +346,12 @@
             <!-- Round 5 - Czech Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/most.jpg" alt="Czech Round" onerror="this.parentElement.innerHTML='Czech Republic'">
+                    <img src="images/tracks/most.jpg" alt="Czech Round" onerror="this.parentElement.innerHTML='CZ'">
                 </div>
                 <div class="race-date">May 15-17</div>
                 <div class="race-country">
                     <span class="country-flag">🇨🇿</span>
-                    <span>Czech Round</span>
+                    <span>CZ</span>
                 </div>
                 <div class="track-name">Round 5</div>
                 <div class="track-length"></div>
@@ -362,12 +361,12 @@
             <!-- Round 6 - Aragon Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/aragon.jpg" alt="Aragon Round" onerror="this.parentElement.innerHTML='Aragon'">
+                    <img src="images/tracks/aragon.jpg" alt="Aragon Round" onerror="this.parentElement.innerHTML='ES'">
                 </div>
                 <div class="race-date">May 29-31</div>
                 <div class="race-country">
                     <span class="country-flag">🇪🇸</span>
-                    <span>Aragon Round</span>
+                    <span>ES</span>
                 </div>
                 <div class="track-name">Round 6</div>
                 <div class="track-length"></div>
@@ -377,12 +376,12 @@
             <!-- Round 7 - Emilia-Romagna Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/misano.jpg" alt="Emilia-Romagna Round" onerror="this.parentElement.innerHTML='Emilia-Romagna'">
+                    <img src="images/tracks/misano.jpg" alt="Emilia-Romagna Round" onerror="this.parentElement.innerHTML='IT'">
                 </div>
                 <div class="race-date">June 12-14</div>
                 <div class="race-country">
                     <span class="country-flag">🇮🇹</span>
-                    <span>Emilia-Romagna Round</span>
+                    <span>IT</span>
                 </div>
                 <div class="track-name">Round 7</div>
                 <div class="track-length"></div>
@@ -392,12 +391,12 @@
             <!-- Round 9 - French Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/magny-cours.jpg" alt="French Round" onerror="this.parentElement.innerHTML='France'">
+                    <img src="images/tracks/magny-cours.jpg" alt="French Round" onerror="this.parentElement.innerHTML='FR'">
                 </div>
                 <div class="race-date">September 4-6</div>
                 <div class="race-country">
                     <span class="country-flag">🇫🇷</span>
-                    <span>French Round</span>
+                    <span>FR</span>
                 </div>
                 <div class="track-name">Round 9</div>
                 <div class="track-length"></div>
@@ -407,12 +406,12 @@
             <!-- Round 10 - Italian Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/imola.jpg" alt="Italian Round" onerror="this.parentElement.innerHTML='Italy'">
+                    <img src="images/tracks/imola.jpg" alt="Italian Round" onerror="this.parentElement.innerHTML='IT'">
                 </div>
                 <div class="race-date">September 25-27</div>
                 <div class="race-country">
                     <span class="country-flag">🇮🇹</span>
-                    <span>Italian Round</span>
+                    <span>IT</span>
                 </div>
                 <div class="track-name">Round 10</div>
                 <div class="track-length"></div>
@@ -422,12 +421,12 @@
             <!-- Round 12 - Spanish Round -->
             <div class="race-row">
                 <div class="track-image">
-                    <img src="images/tracks/jerez.jpg" alt="Spanish Round" onerror="this.parentElement.innerHTML='Spain'">
+                    <img src="images/tracks/jerez.jpg" alt="Spanish Round" onerror="this.parentElement.innerHTML='ES'">
                 </div>
                 <div class="race-date">October 16-18</div>
                 <div class="race-country">
                     <span class="country-flag">🇪🇸</span>
-                    <span>Spanish Round</span>
+                    <span>ES</span>
                 </div>
                 <div class="track-name">Round 12</div>
                 <div class="track-length"></div>


### PR DESCRIPTION
- Make SBK logo fill the entire hero tile as background
- Add WorldSBK link to Portuguese Round with UTM tracking parameters
- Replace country names with 2-letter ISO codes (PT, NL, CZ, ES, IT, FR)