### PR TITLE
Remove text overlays from SBK logo section

### DIFF
--- a/events.html
+++ b/events.html
@@ -306,11 +306,7 @@
 
     <main>
         <div class="page-hero" style="background: url('images/SBK_Logo.jpg') center/cover no-repeat; min-height: 300px; display: flex; flex-direction: column; justify-content: center; align-items: center;">
-            <h1 style="text-shadow: 2px 2px 4px rgba(0,0,0,0.8);">2026 Racing Calendar</h1>
-            <p style="text-shadow: 1px 1px 3px rgba(0,0,0,0.8);">Follow Harrison Dessoy through the world's premier motorcycle racing championship</p>
         </div>
-
-        <h2>World Sportbike Races</h2>
 
         <div class="races-grid">
             <!-- Round 2 - Portuguese Round -->


### PR DESCRIPTION
- Remove h1 "2026 Racing Calendar" overlaid on logo
- Remove subtitle paragraph overlaid on logo
- Remove "World Sportbike Races" h2 heading