### PR TITLE
Move country flags to first column and update Portugal venue

### DIFF
--- a/events.html
+++ b/events.html
@@ -123,7 +123,7 @@
 
         .race-row {
             display: grid;
-            grid-template-columns: 120px 150px 150px 2fr 120px 150px;
+            grid-template-columns: 50px 120px 150px 2fr 120px 150px;
             gap: 1.5rem;
             align-items: center;
             background: var(--light);
@@ -175,11 +175,17 @@
         }
 
         .country-flag {
-            width: 32px;
-            height: 24px;
+            width: 40px;
+            height: 30px;
             object-fit: cover;
             border-radius: 3px;
             box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+        }
+
+        .venue-logo {
+            width: 20px;
+            height: 20px;
+            object-fit: contain;
         }
 
         .track-name {
@@ -240,7 +246,7 @@
 
         @media (max-width: 1200px) {
             .race-row {
-                grid-template-columns: 100px 130px 130px 1fr 100px 130px;
+                grid-template-columns: 50px 100px 130px 1fr 100px 130px;
                 gap: 1rem;
                 padding: 1rem;
             }
@@ -315,121 +321,114 @@
         <div class="races-grid">
             <!-- Round 2 - Portuguese Round -->
             <a href="https://www.worldsbk.com/en/event/POR/2026?utm_campaign=EN_worldSBK&utm_source=web_DessoyRacing" target="_blank" class="race-row" style="text-decoration: none; color: inherit;">
+                <img class="country-flag" src="https://flagcdn.com/w40/pt.png" alt="Portugal">
                 <div class="track-image">
                     <img src="images/tracks/portimao.jpg" alt="Portuguese Round" onerror="this.parentElement.innerHTML='PT'">
                 </div>
                 <div class="race-date">March 20-22</div>
                 <div class="race-country">
-                    <img class="country-flag" src="https://flagcdn.com/w40/pt.png" alt="Portugal">
-                    <span>PT</span>
+                    <img class="venue-logo" src="images/POR.svg" alt="Portimão">
+                    <span>Portimão</span>
                 </div>
                 <div class="track-name">Round 2</div>
-                <div class="track-length"></div>
                 <span class="race-report-btn">Race Report</span>
             </a>
 
             <!-- Round 3 - Dutch Round -->
             <div class="race-row">
+                <img class="country-flag" src="https://flagcdn.com/w40/nl.png" alt="Netherlands">
                 <div class="track-image">
                     <img src="images/tracks/assen.jpg" alt="Dutch Round" onerror="this.parentElement.innerHTML='NL'">
                 </div>
                 <div class="race-date">April 17-19</div>
                 <div class="race-country">
-                    <img class="country-flag" src="https://flagcdn.com/w40/nl.png" alt="Netherlands">
                     <span>NL</span>
                 </div>
                 <div class="track-name">Round 3</div>
-                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
             <!-- Round 5 - Czech Round -->
             <div class="race-row">
+                <img class="country-flag" src="https://flagcdn.com/w40/cz.png" alt="Czech Republic">
                 <div class="track-image">
                     <img src="images/tracks/most.jpg" alt="Czech Round" onerror="this.parentElement.innerHTML='CZ'">
                 </div>
                 <div class="race-date">May 15-17</div>
                 <div class="race-country">
-                    <img class="country-flag" src="https://flagcdn.com/w40/cz.png" alt="Czech Republic">
                     <span>CZ</span>
                 </div>
                 <div class="track-name">Round 5</div>
-                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
             <!-- Round 6 - Aragon Round -->
             <div class="race-row">
+                <img class="country-flag" src="https://flagcdn.com/w40/es.png" alt="Spain">
                 <div class="track-image">
                     <img src="images/tracks/aragon.jpg" alt="Aragon Round" onerror="this.parentElement.innerHTML='ES'">
                 </div>
                 <div class="race-date">May 29-31</div>
                 <div class="race-country">
-                    <img class="country-flag" src="https://flagcdn.com/w40/es.png" alt="Spain">
                     <span>ES</span>
                 </div>
                 <div class="track-name">Round 6</div>
-                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
             <!-- Round 7 - Emilia-Romagna Round -->
             <div class="race-row">
+                <img class="country-flag" src="https://flagcdn.com/w40/it.png" alt="Italy">
                 <div class="track-image">
                     <img src="images/tracks/misano.jpg" alt="Emilia-Romagna Round" onerror="this.parentElement.innerHTML='IT'">
                 </div>
                 <div class="race-date">June 12-14</div>
                 <div class="race-country">
-                    <img class="country-flag" src="https://flagcdn.com/w40/it.png" alt="Italy">
                     <span>IT</span>
                 </div>
                 <div class="track-name">Round 7</div>
-                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
             <!-- Round 9 - French Round -->
             <div class="race-row">
+                <img class="country-flag" src="https://flagcdn.com/w40/fr.png" alt="France">
                 <div class="track-image">
                     <img src="images/tracks/magny-cours.jpg" alt="French Round" onerror="this.parentElement.innerHTML='FR'">
                 </div>
                 <div class="race-date">September 4-6</div>
                 <div class="race-country">
-                    <img class="country-flag" src="https://flagcdn.com/w40/fr.png" alt="France">
                     <span>FR</span>
                 </div>
                 <div class="track-name">Round 9</div>
-                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
             <!-- Round 10 - Italian Round -->
             <div class="race-row">
+                <img class="country-flag" src="https://flagcdn.com/w40/it.png" alt="Italy">
                 <div class="track-image">
                     <img src="images/tracks/imola.jpg" alt="Italian Round" onerror="this.parentElement.innerHTML='IT'">
                 </div>
                 <div class="race-date">September 25-27</div>
                 <div class="race-country">
-                    <img class="country-flag" src="https://flagcdn.com/w40/it.png" alt="Italy">
                     <span>IT</span>
                 </div>
                 <div class="track-name">Round 10</div>
-                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
 
             <!-- Round 12 - Spanish Round -->
             <div class="race-row">
+                <img class="country-flag" src="https://flagcdn.com/w40/es.png" alt="Spain">
                 <div class="track-image">
                     <img src="images/tracks/jerez.jpg" alt="Spanish Round" onerror="this.parentElement.innerHTML='ES'">
                 </div>
                 <div class="race-date">October 16-18</div>
                 <div class="race-country">
-                    <img class="country-flag" src="https://flagcdn.com/w40/es.png" alt="Spain">
                     <span>ES</span>
                 </div>
                 <div class="track-name">Round 12</div>
-                <div class="track-length"></div>
                 <button class="race-report-btn">Race Report</button>
             </div>
         </div>


### PR DESCRIPTION
- Relocate country flags to be the first column in grid layout
- Update Portugal entry: change PT to Portimão with POR.svg logo
- Update grid template columns to accommodate flag column
- Remove empty track-length divs