### PR TITLE
Add XML sitemap for SEO and search engine discovery

### DIFF
--- a/SITEMAP_MAINTENANCE.md
+++ b/SITEMAP_MAINTENANCE.md
@@ -1,0 +1,88 @@
+# Sitemap Maintenance Guide
+
+## Important: Keep sitemap.xml Updated
+
+The `sitemap.xml` file helps search engines discover and index all pages on the website. It's crucial to keep it updated whenever you make changes to the site structure.
+
+## When to Update sitemap.xml
+
+Update the sitemap whenever you:
+- ✅ Add a new HTML page
+- ✅ Remove an existing page
+- ✅ Change page URLs or filenames
+- ✅ Make significant content updates to important pages
+
+## How to Update
+
+### 1. Manual Update
+Edit `sitemap.xml` and add/remove/modify `<url>` entries:
+
+```xml
+<url>
+  <loc>https://dessoyracing.com/your-new-page.html</loc>
+  <changefreq>weekly</changefreq>
+  <priority>0.8</priority>
+</url>
+```
+
+### 2. Priority Guidelines
+- **1.0**: Homepage (index.html)
+- **0.9**: Key pages (fanclub, merchandise)
+- **0.8**: Important content (events)
+- **0.7**: Secondary content (nft, behind-the-scenes)
+- **0.6**: News/updates
+- **0.5**: Sponsor pages
+- **0.3**: Utility pages (success, cancel)
+
+### 3. Change Frequency Guidelines
+- **daily**: Frequently changing content
+- **weekly**: Regular updates (main pages)
+- **monthly**: Occasional updates (news, sponsors)
+- **yearly**: Rarely changes (utility pages)
+
+## Current Pages in Sitemap
+
+Last updated: 2025-11-26
+
+### Main Pages
+- index.html
+- fanclub.html
+- merchandise.html
+- events.html
+- nft.html
+- behind-the-scenes.html
+
+### News/Updates
+- motorcycle-live-announcement.html
+- training-update.html
+
+### Sponsor Pages
+- sponsor-arc-on.html
+- sponsor-mark-walker-coaching.html
+- sponsor-martin-sheath.html
+- sponsor-phr-performance.html
+- sponsor-speedtech.html
+- sponsor-triumph-east-london.html
+- sponsor-twotyres.html
+- sponsor-weise.html
+- sponsor-zerofit.html
+
+### Transaction Pages
+- success.html
+- cancel.html
+
+## Verification
+
+After updating, verify your sitemap:
+1. Check XML syntax is valid
+2. Test at: https://www.xml-sitemaps.com/validate-xml-sitemap.html
+3. Submit to Google Search Console: https://search.google.com/search-console
+
+## Excluded Files
+
+The following files are intentionally excluded from the sitemap:
+- `google-apps-script/form-update-example.html` (internal utility)
+
+## Reminder
+
+⚠️ **Remember to update this file when adding or removing pages from the sitemap!**

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+# Sitemap location
+Sitemap: https://dessoyracing.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- Main Pages -->
+  <url>
+    <loc>https://dessoyracing.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/fanclub.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/merchandise.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/events.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/nft.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/behind-the-scenes.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- News/Updates -->
+  <url>
+    <loc>https://dessoyracing.com/motorcycle-live-announcement.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/training-update.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Sponsor Pages -->
+  <url>
+    <loc>https://dessoyracing.com/sponsor-arc-on.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/sponsor-mark-walker-coaching.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/sponsor-martin-sheath.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/sponsor-phr-performance.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/sponsor-speedtech.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/sponsor-triumph-east-london.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/sponsor-twotyres.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/sponsor-weise.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/sponsor-zerofit.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <!-- Transaction Pages -->
+  <url>
+    <loc>https://dessoyracing.com/success.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://dessoyracing.com/cancel.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
- Created sitemap.xml with all site pages organized by priority
- Added robots.txt with sitemap reference
- Created SITEMAP_MAINTENANCE.md with maintenance instructions and reminders
- Included all main pages, news/updates, sponsor pages, and transaction pages
- Set appropriate priorities and change frequencies for each page type