### PR TITLE
Add Buy Tickets button to all event rows on events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -123,7 +123,7 @@
 
         .race-row {
             display: grid;
-            grid-template-columns: 50px 150px 150px 2fr 120px 150px;
+            grid-template-columns: 50px 150px 150px 2fr 120px 150px 150px;
             gap: 1.5rem;
             align-items: center;
             background: var(--light);
@@ -252,7 +252,7 @@
 
         @media (max-width: 1200px) {
             .race-row {
-                grid-template-columns: 50px 130px 130px 1fr 100px 130px;
+                grid-template-columns: 50px 130px 130px 1fr 100px 130px 130px;
                 gap: 1rem;
                 padding: 1rem;
             }
@@ -323,7 +323,7 @@
 
         <div class="races-grid">
             <!-- Round 2 - Portuguese Round -->
-            <a href="https://www.worldsbk.com/en/event/POR/2026?utm_campaign=EN_worldSBK&utm_source=web_DessoyRacing" target="_blank" class="race-row" style="text-decoration: none; color: inherit;">
+            <div class="race-row">
                 <img class="country-flag" src="https://flagcdn.com/w40/pt.png" alt="Portugal">
                 <div class="country-name">Portugal</div>
                 <div class="race-date">March 20-22</div>
@@ -332,8 +332,9 @@
                     <span>Portimão</span>
                 </div>
                 <div class="track-name">Round 2</div>
-                <span class="race-report-btn">Race Report</span>
-            </a>
+                <a href="https://www.worldsbk.com/en/event/POR/2026?utm_campaign=EN_worldSBK&utm_source=web_DessoyRacing" class="race-report-btn" target="_blank">Race Report</a>
+                <button class="race-report-btn">Buy Tickets</button>
+            </div>
 
             <!-- Round 3 - Dutch Round -->
             <div class="race-row">
@@ -344,6 +345,7 @@
                     <span>TT Circuit Assen</span>
                 </div>
                 <div class="track-name">Round 3</div>
+                <button class="race-report-btn">Race Report</button>
                 <a href="https://tickets.worldsbk.com/en/25751-netherlands/?utm_source=worldsbk.com&utm_medium=web&utm_campaign=calendar26_ned" class="race-report-btn" target="_blank">Buy Tickets</a>
             </div>
 
@@ -357,6 +359,7 @@
                 </div>
                 <div class="track-name">Round 5</div>
                 <button class="race-report-btn">Race Report</button>
+                <button class="race-report-btn">Buy Tickets</button>
             </div>
 
             <!-- Round 6 - Aragon Round -->
@@ -369,6 +372,7 @@
                 </div>
                 <div class="track-name">Round 6</div>
                 <button class="race-report-btn">Race Report</button>
+                <button class="race-report-btn">Buy Tickets</button>
             </div>
 
             <!-- Round 7 - Emilia-Romagna Round -->
@@ -381,6 +385,7 @@
                 </div>
                 <div class="track-name">Round 7</div>
                 <button class="race-report-btn">Race Report</button>
+                <button class="race-report-btn">Buy Tickets</button>
             </div>
 
             <!-- Round 9 - French Round -->
@@ -393,6 +398,7 @@
                 </div>
                 <div class="track-name">Round 9</div>
                 <button class="race-report-btn">Race Report</button>
+                <button class="race-report-btn">Buy Tickets</button>
             </div>
 
             <!-- Round 10 - Italian Round -->
@@ -405,6 +411,7 @@
                 </div>
                 <div class="track-name">Round 10</div>
                 <button class="race-report-btn">Race Report</button>
+                <button class="race-report-btn">Buy Tickets</button>
             </div>
 
             <!-- Round 12 - Spanish Round -->
@@ -417,6 +424,7 @@
                 </div>
                 <div class="track-name">Round 12</div>
                 <button class="race-report-btn">Race Report</button>
+                <button class="race-report-btn">Buy Tickets</button>
             </div>
         </div>
     </main>


### PR DESCRIPTION
Updated the events page to display both Race Report and Buy Tickets buttons for all event rows. Modified the grid layout to accommodate the additional button column and ensured responsive design compatibility.