### PR TITLE
Remove top logo and revert styling changes

### DIFF
--- a/fanclub.html
+++ b/fanclub.html
@@ -488,8 +488,11 @@
         }
 
         .social-links img {
-            background: transparent;
-            border-radius: 50%;
+            background: transparent !important;
+            border-radius: 0;
+            padding: 0;
+            border: none;
+            box-shadow: none;
         }
 
         /* Basket Sidebar */
@@ -706,8 +709,8 @@
     <header>
         <div class="header-content">
             <div class="logo">
-                <a href="index.html">
-                    <img src="images/Harrison Dessoy 2025 logo .png" alt="Harrison Dessoy">
+                <a href="index.html" style="color: var(--light); text-decoration: none; font-size: 1.5rem; font-weight: bold; letter-spacing: 1px;">
+                    Harrison Dessoy
                 </a>
             </div>
             <div class="hamburger" onclick="toggleMenu()">

--- a/index.html
+++ b/index.html
@@ -163,10 +163,6 @@
         }
 
         .hero {
-            background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
-                        url('images/Cadwellpodium.JPG');
-            background-size: cover;
-            background-position: center 30%;
             height: 100vh;
             display: flex;
             align-items: center;
@@ -174,6 +170,46 @@
             text-align: center;
             color: var(--light);
             margin-top: 70px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .hero-background {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            z-index: 0;
+        }
+
+        .hero-background-left {
+            flex: 0 0 48%;
+            background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
+                        url('images/Cadwellpodium.JPG');
+            background-size: cover;
+            background-position: center 30%;
+        }
+
+        .hero-background-separator {
+            flex: 0 0 4%;
+            background: linear-gradient(90deg, rgba(0,0,0,0.8) 0%, rgba(0,0,0,1) 50%, rgba(0,0,0,0.8) 100%);
+        }
+
+        .hero-background-right {
+            flex: 0 0 48%;
+            background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
+                        url('images/SBK_Logo.jpg');
+            background-size: contain;
+            background-position: center;
+            background-repeat: no-repeat;
+            background-color: #1d3557;
+        }
+
+        .hero-content {
+            position: relative;
+            z-index: 1;
         }
 
         .hero-content h1 {
@@ -774,7 +810,7 @@
             gap: 3rem;
             flex-wrap: wrap;
             padding: 3rem 2rem;
-            background: linear-gradient(180deg, #f8f9fa 0%, #e9ecef 100%);
+            background: #ffffff;
             border-top: 1px solid #e0e0e0;
         }
 
@@ -1020,12 +1056,18 @@
                 display: flex;
             }
 
-            .sbk-logo {
-                margin-top: 4rem !important;
+            .hero-background {
+                flex-direction: column;
             }
 
-            .hero-content h1 {
-                margin-top: 1rem;
+            .hero-background-left,
+            .hero-background-right {
+                flex: 1 1 auto;
+            }
+
+            .hero-background-separator {
+                flex: 0 0 20px;
+                background: linear-gradient(180deg, rgba(0,0,0,0.8) 0%, rgba(0,0,0,1) 50%, rgba(0,0,0,0.8) 100%);
             }
 
             nav {
@@ -1114,8 +1156,12 @@
 
     <section id="home" class="active">
         <div class="hero">
+            <div class="hero-background">
+                <div class="hero-background-left"></div>
+                <div class="hero-background-separator"></div>
+                <div class="hero-background-right"></div>
+            </div>
             <div class="hero-content">
-                <img src="images/SBK_Logo.jpg" alt="World Superbike Logo" class="sbk-logo" style="max-width: 300px; width: 100%; height: auto; margin-bottom: 1.5rem; border-radius: 10px;">
                 <h1>Harrison Dessoy</h1>
                 <p style="font-size: 4rem; font-weight: bold; color: var(--light); margin-top: 0.5rem; margin-bottom: 1.5rem;">World Sportbike Rider</p>
                 <a href="#about" class="cta-button" onclick="showSection('about')" style="margin-top: 2rem;">Discover My Journey</a>
@@ -1142,9 +1188,6 @@
             <a href="https://twotyres.co.uk/" target="_blank" rel="noopener">
                 <img src="images/TwoTyres.jpeg" alt="Two Tyres" class="hero-sponsor-logo">
             </a>
-        </div>
-        <div style="background: linear-gradient(135deg, var(--dark) 0%, var(--secondary) 100%); padding: 3rem 2rem; display: flex; justify-content: center; align-items: center;">
-            <img src="images/SBK_Logo.jpg" alt="World Sportbike Logo" style="max-width: 400px; width: 100%; height: auto; border-radius: 10px; box-shadow: 0 5px 20px rgba(0,0,0,0.3);">
         </div>
     </section>
 


### PR DESCRIPTION
- Remove World Sportbike logo from top of home page (kept at bottom)
- Revert sponsor logos section background to plain white
- Remove white background from Facebook logo
- Replace Harrison Dessoy 2025 logo with text in Fan Club page
- Split hero background into Cadwell photo (left) and World Sportbike logo (right) with black separator
- Remove World Sportbike photo from bottom of home page
- Add responsive styling for mobile devices