### PR TITLE
Adjust home logos, divider effect, and social media styling

### DIFF
--- a/fanclub.html
+++ b/fanclub.html
@@ -489,7 +489,7 @@
 
         .social-links img {
             background: transparent !important;
-            border-radius: 0;
+            border-radius: 50%;
             padding: 0;
             border: none;
             box-shadow: none;

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
         }
 
         .hero {
-            height: 100vh;
+            height: 60vh;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -185,7 +185,7 @@
         }
 
         .hero-background-left {
-            flex: 0 0 48%;
+            flex: 0 0 46%;
             background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
                         url('images/Cadwellpodium.JPG');
             background-size: cover;
@@ -193,18 +193,19 @@
         }
 
         .hero-background-separator {
-            flex: 0 0 4%;
-            background: linear-gradient(90deg, rgba(0,0,0,0.8) 0%, rgba(0,0,0,1) 50%, rgba(0,0,0,0.8) 100%);
+            flex: 0 0 8%;
+            background: linear-gradient(90deg, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.3) 50%, rgba(0,0,0,0.1) 100%);
+            backdrop-filter: blur(15px);
+            -webkit-backdrop-filter: blur(15px);
         }
 
         .hero-background-right {
-            flex: 0 0 48%;
+            flex: 0 0 46%;
             background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
                         url('images/SBK_Logo.jpg');
             background-size: contain;
             background-position: center;
             background-repeat: no-repeat;
-            background-color: #1d3557;
         }
 
         .hero-content {
@@ -1035,7 +1036,7 @@
             object-fit: contain;
             transition: all 0.3s;
             background: transparent !important;
-            border-radius: 0;
+            border-radius: 50%;
             padding: 0;
             border: none;
             box-shadow: none;
@@ -1066,8 +1067,10 @@
             }
 
             .hero-background-separator {
-                flex: 0 0 20px;
-                background: linear-gradient(180deg, rgba(0,0,0,0.8) 0%, rgba(0,0,0,1) 50%, rgba(0,0,0,0.8) 100%);
+                flex: 0 0 30px;
+                background: linear-gradient(180deg, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.3) 50%, rgba(0,0,0,0.1) 100%);
+                backdrop-filter: blur(15px);
+                -webkit-backdrop-filter: blur(15px);
             }
 
             nav {


### PR DESCRIPTION
- Reduced hero section height from 100vh to 60vh to shorten both logos
- Removed blue background from sportbike logo section for cleaner display
- Changed divider from sharp black line to blurred effect with backdrop-filter
- Widened separator from 4% to 8% for better visual transition
- Updated social media link styling: changed border-radius from 0 to 50% for Facebook icon
- Applied border-radius change across index.html and fanclub.html