### PR TITLE
Fix internal docs/skills that drifted behind this session's own changes

### DIFF
--- a/.claude/skills/add-product/SKILL.md
+++ b/.claude/skills/add-product/SKILL.md
@@ -16,7 +16,7 @@ Every buy button is a direct link to a Stripe-hosted payment page: `<a href="htt
 ## Steps
 
 1. Optimize image(s) → `images/` (front + rear shots use the carousel pattern — see the hoodie card's `product-carousel` markup).
-2. Add a `.product-card` to the grid in `merchandise.html`, copying an existing card: image (or carousel), `<h3>` name, `.product-price` (£, `.toFixed(2)` style formatting, e.g. `£25.00`), `.shipping-note` if applicable, description, size selector if sizes exist, buy button with the real `buy.stripe.com` link (`target="_blank" rel="noopener"`).
+2. Add a `.product-card` to the grid in `merchandise.html`, copying an existing card: image (or carousel), `<h3>` name, `.product-price` (£, `.toFixed(2)` style formatting, e.g. `£25.00`), `.shipping-note` if applicable, description, size selector if sizes exist, buy button with the real `buy.stripe.com` link (`target="_blank" rel="noopener"`). If it's a carousel, add `loading="lazy"` to every slide after the first (front-facing) one — those are never visible without a user clicking the arrow, so it's free perf with zero risk.
 3. If a product is retired, remove its card and (ask first) archive its images.
 
 ## Verify

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -16,12 +16,12 @@ Copy the structurally closest existing page:
 
 ## 2. Required in every page
 
-- `<html lang="en">`, viewport meta, exactly one `<h1>`, `<meta name="description">` (~150 chars)
+- `<html lang="en">`, viewport meta, favicon `<link>` block (copy the 4 lines from any page), exactly one `<h1>`, `<meta name="description">` (~150 chars)
 - GA snippet in `<head>` (ID `G-Z0P3DBDMDZ` — copy verbatim from the base page)
 - Shared nav: empty `<nav id="nav"><ul></ul></nav>`, `<script src="nav.js">`, then `renderNav('<pageId or null>', false)` — **never a hardcoded menu**
-- Footer with contact block, copyright, "Racing at the Highest Level", and the DessoyArt credit line (copy the whole `<footer>` from the base page)
+- Shared footer: empty `<footer></footer>`, `<script src="footer.js">`, then `renderFooter({...})` — **never hardcode footer HTML**, that's exactly the copy-paste drift that used to cause inconsistent contact emails and stale copyright years across the site. Pass `withSocial: true` for pages with the full nav, `false` for minimal pages (see how `behind-the-scenes.html`/`nft.html` call it); `copyrightName`/`copyrightSuffix` only if this page needs different text than the default "Harrison Dessoy. All rights reserved."
 - Inline `<style>` using the shared tokens (`--primary: #e63946`, `--secondary: #1d3557`, etc.)
-- External links `target="_blank" rel="noopener"`
+- External links `target="_blank" rel="noopener"`; internal links same-tab, no exceptions
 
 Optional per purpose: newsletter popup (copy the modal block + `newsletter-popup.css`/`.js` includes from `events.html`).
 

--- a/.claude/skills/new-sponsor-page/SKILL.md
+++ b/.claude/skills/new-sponsor-page/SKILL.md
@@ -22,8 +22,9 @@ Run the `optimize-image` skill conventions: WebP preferred, ≤300 KB, lowercase
 ## 3. Create `sponsor-<name>.html`
 
 Copy the structure of the most recently added sponsor page (currently `sponsor-rockcameras.html`) — do not invent a new layout. Then:
-- Update title, `<h1>` and `<meta name="description">` (add both — the older template pages lack them, new pages must have them), hero, description, links, logo
-- Keep the GA snippet (`G-Z0P3DBDMDZ`), footer with the DessoyArt credit line, and `© <current year> <Sponsor Name>. Official Partner of Harrison Dessoy.`
+- Update title, `<meta name="description">`, description, links, logo
+- **`<h1>{Sponsor Name}</h1>` goes inside the `.sponsor-hero` div**, before or alongside the logo image. Every sponsor page already has `.sponsor-hero h1` CSS predefined (font-size, uppercase, letter-spacing) — for a long time all 13 pages had this CSS with no actual `<h1>` element using it, just a bare logo image (fixed 2026-07-10). Don't recreate that gap: the heading is not optional decoration, it's required for `site-check.py` and for the page to make sense to a screen reader.
+- Footer: empty `<footer></footer>` + `<script src="footer.js">` + `renderFooter({ withSocial: false, copyrightName: '<Sponsor Name>', copyrightSuffix: 'Official Partner of Harrison Dessoy.' })` — **never hardcode the footer**. Keep the GA snippet (`G-Z0P3DBDMDZ`) and the favicon `<link>` block too.
 - External links `target="_blank" rel="noopener"`; internal links same-tab
 
 ## 4. The three side-updates (the part that gets forgotten)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,18 +6,20 @@ Full details in `_internal/CLAUDE_CODE_GUIDE.md` — read it before structural c
 
 ## Invariants — never violate these
 
-- **Navigation lives in `nav.js`.** Pages have an empty `<nav id="nav"><ul></ul></nav>` and call `renderNav('<pageId>', isHome)`. Never hardcode a menu into a page — hardcoded copies are exactly what drifted before.
+- **Navigation lives in `nav.js`, the footer lives in `footer.js`.** Pages have an empty `<nav id="nav"><ul></ul></nav>` + `<footer></footer>` and call `renderNav('<pageId>', isHome)` / `renderFooter({withSocial, copyrightName, copyrightSuffix})`. Never hardcode either into a page — hardcoded copies are exactly what drifted before (a missing nav item, inconsistent contact email, stale copyright years, orphaned policy-page links — all fixed 2026-07-10 by centralizing).
 - **Anything rendered from `data/*.json` is untrusted.** Those files are auto-committed by the external Publisher service from social/Mailchimp APIs. Always pass text through `escapeHtml()` and URLs through `safeUrl()` (both in `index.html`) before inserting into the DOM. See `_internal/FEED_SECURITY_CHANGES.md`.
 - **Do not delete "orphaned-looking" folders** (`2023/`, `2024/`, UUID dirs, `img_*/`, `about-me/`, `alan-roberts/`) — they are redirects for old external links. `partnership-menu.html` is intentionally hidden from nav; keep it.
-- **Purchases are direct `buy.stripe.com` payment links** — there is no on-site cart or Stripe.js checkout session. Never handle card data or keys in this repo.
+- **Purchases are direct `buy.stripe.com` payment links** — there is no on-site cart or Stripe.js checkout session, and no `basket.js` (removed 2026-07-10 — it was fully vestigial; don't reintroduce cart/basket machinery). Never handle card data or keys in this repo.
+- **The mobile hamburger is a `<button>`, not a `<div>`** (`aria-label="Menu" aria-expanded="false" aria-controls="nav"`), with `nav.js` keeping `aria-expanded` in sync. Don't revert to a div-with-onclick.
 
 ## Every new page needs
 
 1. Google Analytics snippet in `<head>` (ID `G-Z0P3DBDMDZ` — copy from any page)
-2. Shared nav (`nav.js` + `renderNav`) and the standard footer **including the DessoyArt credit line**
-3. Exactly one `<h1>`, a `<meta name="description">`, `lang="en"`, viewport meta
-4. An entry in `sitemap.xml` (see `_internal/SITEMAP_MAINTENANCE.md` for priorities)
-5. A link from at least one existing page
+2. Favicon `<link>` block (copy from any page — 4 lines, `favicon.ico` + 2 PNG sizes + apple-touch-icon)
+3. Shared nav + footer (`nav.js`/`footer.js`, see above) **including the DessoyArt credit line**
+4. Exactly one `<h1>`, a `<meta name="description">`, `lang="en"`, viewport meta
+5. An entry in `sitemap.xml` (see `_internal/SITEMAP_MAINTENANCE.md` for priorities)
+6. A link from at least one existing page
 
 Use the `new-page` or `new-sponsor-page` skill — they encode this checklist.
 

--- a/_internal/CLAUDE_CODE_GUIDE.md
+++ b/_internal/CLAUDE_CODE_GUIDE.md
@@ -133,7 +133,8 @@ All other CSS is **inline** inside `<style>` blocks in each HTML file's `<head>`
 
 - Hamburger menu is a real `<button type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav">` on the 5 full-nav pages (was a `<div onclick>` until 2026-07-10). `nav.js` keeps `aria-expanded` in sync — don't revert to a div.
 - Every real content page has exactly one `<h1>`. `site-check.py` enforces this — a new page failing this check means the title text is missing or duplicated, not that the check is wrong.
-- External links use `rel="noopener"` on `target="_blank"`; internal links stay same-tab (the one intentional exception is the EGR/Martin Sheath link in the hero strip, which opens a local page in a new tab — inconsistent but low-priority, see AUDIT.md).
+- External links use `rel="noopener"` on `target="_blank"`; internal links stay same-tab, no exceptions (the one that existed, the EGR/Martin Sheath hero-strip link, was fixed 2026-07-10).
+- The 5 full-nav pages have a "Skip to content" link as the first element in `<body>` (visually hidden until keyboard-focused). On index.html it targets `#home` rather than a generic `#main-content` id — that page toggles section visibility via `section.active`/`showSection()`, and a plain new id on `<main>` would collide with the hash-routing (loading `#main-content` would hide every section with nothing to show in their place). Keep using `#home` there if you touch this.
 
 ---
 
@@ -195,6 +196,8 @@ All site images live in `/images/` (~28 MB, down from ~98 MB after the 2026-07-1
 **Convention for new images:** WebP, ≤300–500 KB, lowercase-hyphenated filename (`sponsor-name-logo.webp`, not `Sponsor Name (2).PNG`). Use the `optimize-image` Claude Code skill — `cwebp` is installed via Homebrew on the primary dev machine (verified 2026-07-10: turns an 8.5 MB source photo into ~45 KB with no visible quality loss). Existing pre-2026-07-10 filenames keep spaces/mixed case; match them exactly since the deploy host is case-sensitive.
 
 `scripts/site-check.py` flags any committed image over 500 KB — a growing list of pre-existing large photos (data/Instagram JPEGs, a few `images/IMG_*.JPEG` files) is tracked as ongoing warnings in `AUDIT.md`, not yet cleaned up.
+
+**`loading="lazy"`:** applied 2026-07-10 to below-the-fold `<img>` tags (index.html's sponsor grid, events.html's flags/venue logos, merchandise.html's rear/back carousel photos). Leave it off anything likely to be in the initial viewport (header logo, hero images, front-facing product photos) — it only helps if the browser can skip a real network fetch. Note this doesn't apply to the "News"/social-feed cards on index.html — those render via CSS `background-image` on a `<div>`, and the `loading` attribute only works on `<img>`/`<iframe>`.
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only change (no site behavior affected — `_internal/` and `.claude/` are both excluded from the GitHub Pages build).

While double-checking whether all documentation reflected the previous audit session's work, found that a few docs described patterns that session's own earlier commits had already superseded — which would have caused the same drift the whole audit was about, the next time someone followed them:

- `CLAUDE.md` didn't mention `footer.js` at all, despite it being extracted in the very next commit after this file was written
- `.claude/skills/new-page/SKILL.md` told future sessions to "copy the whole `<footer>` from the base page" — the exact copy-paste pattern that caused the original inconsistent-email/stale-copyright-year bugs
- `.claude/skills/new-sponsor-page/SKILL.md` had the same footer issue, and didn't make explicit that the sponsor `<h1>` belongs inside `.sponsor-hero` (all 13 sponsor pages had that CSS predefined with no `<h1>` using it, until fixed earlier this session)
- `.claude/skills/add-product/SKILL.md` — added the `loading="lazy"` convention for carousel rear images
- `_internal/CLAUDE_CODE_GUIDE.md` — removed a now-false claim about an "intentional" inconsistent internal link (fixed later the same session), added the skip-to-content link note and a `loading="lazy"` note

## Test plan
- [x] `scripts/site-check.py` — zero failures
- [x] Repo-wide grep confirming no other stale references to removed patterns (`basket.js`, old sponsor-page counts, etc.) remain anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)